### PR TITLE
feat : 관리자가 숨은캐스퍼찾기 게임 기간을 등록(업데이트) 하는 api 생성 (CC-128)

### DIFF
--- a/src/main/java/ai/softeer/caecae/admin/api/AdminController.java
+++ b/src/main/java/ai/softeer/caecae/admin/api/AdminController.java
@@ -2,10 +2,13 @@ package ai.softeer.caecae.admin.api;
 
 import ai.softeer.caecae.admin.domain.dto.response.DrawResponseDto;
 import ai.softeer.caecae.admin.service.AdminService;
+import ai.softeer.caecae.findinggame.service.FindingGameService;
 import ai.softeer.caecae.global.dto.response.SuccessResponse;
 import ai.softeer.caecae.global.enums.SuccessCode;
+import ai.softeer.caecae.racinggame.domain.dto.request.RegisterFindingGamePeriodRequestDto;
 import ai.softeer.caecae.racinggame.domain.dto.request.RegisterRacingGameInfoRequestDto;
 import ai.softeer.caecae.racinggame.domain.dto.response.RacingGameInfoResponseDto;
+import ai.softeer.caecae.racinggame.domain.dto.response.RegisterFindingGamePeriodResponseDto;
 import ai.softeer.caecae.racinggame.domain.dto.response.RegisterRacingGameInfoResponseDto;
 import ai.softeer.caecae.racinggame.service.RacingGameInfoService;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminController {
     private final RacingGameInfoService racingGameService;
+    private final FindingGameService findingGameService;
     private final AdminService adminService;
 
     /**
@@ -47,5 +51,18 @@ public class AdminController {
     @PostMapping("/racing/draw")
     public ResponseEntity<SuccessResponse<List<DrawResponseDto>>> drawRacingGameWinner() {
         return SuccessResponse.of(SuccessCode.OK, adminService.drawRacingGameWinner());
+    }
+
+    /**
+     * 어드민이 숨은캐스퍼찾기 게임 기간을 등록하는 api
+     *
+     * @param req 게임 시작 날짜
+     * @return 등록된 게임 시작 날짜, 종료 날짜(+6일)
+     */
+    @PostMapping("/finding/period")
+    public ResponseEntity<SuccessResponse<RegisterFindingGamePeriodResponseDto>>
+    registerFindingGamePeriod(@RequestBody RegisterFindingGamePeriodRequestDto req) {
+        RegisterFindingGamePeriodResponseDto res = findingGameService.registerFindingGamePeriod(req);
+        return SuccessResponse.of(SuccessCode.CREATED, res);
     }
 }

--- a/src/main/java/ai/softeer/caecae/findinggame/domain/entity/FindingGame.java
+++ b/src/main/java/ai/softeer/caecae/findinggame/domain/entity/FindingGame.java
@@ -1,18 +1,19 @@
 package ai.softeer.caecae.findinggame.domain.entity;
 
 import ai.softeer.caecae.global.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDateTime;
 
 @Entity
 public class FindingGame extends BaseEntity {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
     @Column(nullable = false)
+    @ColumnDefault("no-image")
     private String imageUrl;
 
     @Column(nullable = false)
@@ -22,5 +23,6 @@ public class FindingGame extends BaseEntity {
     private LocalDateTime endTime;
 
     @Column(nullable = false)
+    @ColumnDefault("315")
     private int numberOfWinners;
 }

--- a/src/main/java/ai/softeer/caecae/findinggame/domain/entity/FindingGame.java
+++ b/src/main/java/ai/softeer/caecae/findinggame/domain/entity/FindingGame.java
@@ -1,19 +1,23 @@
 package ai.softeer.caecae.findinggame.domain.entity;
 
+import ai.softeer.caecae.findinggame.domain.enums.AnswerType;
 import ai.softeer.caecae.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import org.hibernate.annotations.ColumnDefault;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FindingGame extends BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE) //Bulk insert를 위한 pk type 설정
     private Integer id;
 
     @Column(nullable = false)
-    @ColumnDefault("no-image")
     private String imageUrl;
 
     @Column(nullable = false)
@@ -23,6 +27,16 @@ public class FindingGame extends BaseEntity {
     private LocalDateTime endTime;
 
     @Column(nullable = false)
-    @ColumnDefault("315")
     private int numberOfWinners;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AnswerType answerType;
+
+    // 숨은 캐스퍼찾기 기간 업데이트
+    public FindingGame updateFindingGamePeriod(LocalDateTime startTime, LocalDateTime endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+        return this;
+    }
 }

--- a/src/main/java/ai/softeer/caecae/findinggame/domain/enums/AnswerType.java
+++ b/src/main/java/ai/softeer/caecae/findinggame/domain/enums/AnswerType.java
@@ -1,0 +1,9 @@
+package ai.softeer.caecae.findinggame.domain.enums;
+
+// 숨은캐스퍼찾기 정답의 타입
+public enum AnswerType {
+    PIXEL,
+    BADGE,
+    UNSELECTED
+
+}

--- a/src/main/java/ai/softeer/caecae/findinggame/repository/FindGameDbRepository.java
+++ b/src/main/java/ai/softeer/caecae/findinggame/repository/FindGameDbRepository.java
@@ -1,0 +1,10 @@
+package ai.softeer.caecae.findinggame.repository;
+
+import ai.softeer.caecae.findinggame.domain.entity.FindingGame;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+// Redis Repository 도 만들어야 하므로 네이밍에 Db를 붙임
+@Repository
+public interface FindGameDbRepository extends JpaRepository<FindingGame, Integer> {
+}

--- a/src/main/java/ai/softeer/caecae/findinggame/service/FindingGameService.java
+++ b/src/main/java/ai/softeer/caecae/findinggame/service/FindingGameService.java
@@ -1,0 +1,67 @@
+package ai.softeer.caecae.findinggame.service;
+
+import ai.softeer.caecae.findinggame.domain.entity.FindingGame;
+import ai.softeer.caecae.findinggame.domain.enums.AnswerType;
+import ai.softeer.caecae.findinggame.repository.FindGameDbRepository;
+import ai.softeer.caecae.racinggame.domain.dto.request.RegisterFindingGamePeriodRequestDto;
+import ai.softeer.caecae.racinggame.domain.dto.response.RegisterFindingGamePeriodResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FindingGameService {
+    private final FindGameDbRepository findGameDbRepository;
+
+    /**
+     * 어드민이 숨은캐스퍼찾기 게임 기간을 등록하는 로직
+     *
+     * @param req 게임 시작 날짜
+     * @return 게임 시작 날짜, 종료 날짜(+6일)
+     */
+    @Transactional
+    public RegisterFindingGamePeriodResponseDto registerFindingGamePeriod(RegisterFindingGamePeriodRequestDto req) {
+        List<FindingGame> findingGames = findGameDbRepository.findAll();
+        // 등록된 게임 정보가 없으면 생성하기
+        if (findingGames.isEmpty()) {
+            findingGames = initFindingGames();
+        }
+
+        // 게임 정보 기간 업데이트
+        LocalDate date = req.startDate();
+        for (FindingGame findingGame : findingGames) {
+            findingGame.updateFindingGamePeriod(
+                    date.atTime(15, 15),
+                    date.plusDays(1).atTime(14, 15)
+            );
+            date = date.plusDays(1);
+        }
+
+
+        findGameDbRepository.saveAll(findingGames);
+
+        return RegisterFindingGamePeriodResponseDto.builder()
+                .startDate(req.startDate())
+                .endDate(req.startDate().plusDays(6))
+                .build();
+    }
+
+    // 7개의 숨은캐스퍼찾기 게임 정보 객체 초기화
+    private List<FindingGame> initFindingGames() {
+        List<FindingGame> findingGames = new ArrayList<>();
+        for (int day = 0; day < 7; day++) {
+            findingGames.add(
+                    FindingGame.builder()
+                            .imageUrl("no-image")
+                            .numberOfWinners(315)
+                            .answerType(AnswerType.UNSELECTED)
+                            .build());
+        }
+        return findingGames;
+    }
+}

--- a/src/main/java/ai/softeer/caecae/racinggame/domain/dto/request/RegisterFindingGamePeriodRequestDto.java
+++ b/src/main/java/ai/softeer/caecae/racinggame/domain/dto/request/RegisterFindingGamePeriodRequestDto.java
@@ -1,0 +1,12 @@
+package ai.softeer.caecae.racinggame.domain.dto.request;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+// 어드민이 숨은캐스퍼찾기 게임 기간을 등록할 때 사용
+@Builder
+public record RegisterFindingGamePeriodRequestDto(
+        LocalDate startDate
+) {
+}

--- a/src/main/java/ai/softeer/caecae/racinggame/domain/dto/response/RegisterFindingGamePeriodResponseDto.java
+++ b/src/main/java/ai/softeer/caecae/racinggame/domain/dto/response/RegisterFindingGamePeriodResponseDto.java
@@ -1,0 +1,15 @@
+package ai.softeer.caecae.racinggame.domain.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+// 어드민이 숨은캐스퍼찾기 게임 기간을 등록할 때 사용
+@Builder
+public record RegisterFindingGamePeriodResponseDto(
+        LocalDate startDate,
+        LocalDate endDate
+
+
+) {
+}


### PR DESCRIPTION
## 📝 작업내용
 - 숨은캐스퍼찾기 기간 등록 서비스로직 개발
 - 시작 날짜만 파라미터로 받아, 7개의 데이터를 bulk insert
 - JPA Bulk Insert를 위해 FindingGame 엔티티 PK 전략을 `SEQUENCE`로 수정

## 💬 침고사항
- 

## 📖 레퍼런스
 - 

